### PR TITLE
(SIMP-305) Update module to use native pkgs

### DIFF
--- a/build/pupmod-tftpboot.spec
+++ b/build/pupmod-tftpboot.spec
@@ -1,7 +1,7 @@
 Summary: TFTPBoot Puppet Module
 Name: pupmod-tftpboot
 Version: 4.1.0
-Release: 6
+Release: 7
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -58,6 +58,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Mon Jul 27 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-7
+- Updated to use the system-provided files where possible.
+
 * Fri Jan 16 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-6
 - Changed puppet-server requirement to puppet
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,17 @@
 #   Determines if non puppet-managed configuration files in
 #   /tftpboot/linux-install/pxelinux.cfg get purged.
 #
+#
+# [*use_os_files*]
+# Type: Boolean
+# Default: True
+#   If true, use the OS provided syslinux packages to obtain the pxelinux.0
+#   file.
+#
+# == TODO
+#
+# Ensure that this module can be used with any target location.
+#
 # == Authors
 #
 # * Trevor Vaughan <tvaughan@onyxpoint.com>
@@ -34,8 +45,14 @@ class tftpboot (
   $client_nets = hiera('client_nets'),
   $rsync_server = hiera('rsync::server'),
   $rsync_timeout = hiera('rsync::timeout','2'),
-  $purge_configs = true
+  $purge_configs = true,
+  $use_os_files = true
 ){
+  validate_string($rsync_server)
+  validate_net_list($client_nets)
+  validate_integer($rsync_timeout)
+  validate_bool($purge_configs)
+
   include 'xinetd'
   include 'rsync'
 
@@ -81,6 +98,37 @@ class tftpboot (
 
   package { 'tftp-server': ensure => 'latest' }
 
+  if $use_os_files {
+    package { 'syslinux-tftpboot': ensure => 'latest' }
+
+    file { '/tftpboot/linux-install/pxelinux.0':
+      ensure  => 'file',
+      owner   => 'root',
+      group   => 'nobody',
+      mode    => '0640',
+      source  => 'file:///var/lib/tftpboot/pxelinux.0',
+      require => Package['syslinux-tftpboot']
+    }
+
+    file { '/tftpboot/linux-install/menu.c32':
+      ensure  => 'file',
+      owner   => 'root',
+      group   => 'nobody',
+      mode    => '0640',
+      source  => 'file:///var/lib/tftpboot/menu.c32',
+      require => Package['syslinux-tftpboot']
+    }
+
+    $_rsync_exclude = [
+      'pxelinux.cfg',
+      'menu.c32',
+      'pxelinux.0'
+    ]
+  }
+  else {
+    $_rsync_exclude = [ 'pxelinux.cfg' ]
+  }
+
   rsync { 'tftpboot':
     user     => 'tftpboot_rsync',
     password => passgen('tftpboot_rsync'),
@@ -88,7 +136,7 @@ class tftpboot (
     target   => '/tftpboot',
     server   => $rsync_server,
     timeout  => $rsync_timeout,
-    exclude  => 'pxelinux.cfg'
+    exclude  => $_rsync_exclude
   }
 
   xinetd::service { 'tftp':
@@ -106,9 +154,4 @@ class tftpboot (
     only_from      => nets2ddq($client_nets),
     log_on_success => 'HOST PID DURATION'
   }
-
-  validate_string($rsync_server)
-  validate_net_list($client_nets)
-  validate_integer($rsync_timeout)
-  validate_bool($purge_configs)
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -57,7 +57,7 @@ describe 'tftpboot' do
       'target' => '/tftpboot',
       'server' => 'rsync.bar.baz',
       'timeout' => '2',
-      'exclude' => 'pxelinux.cfg'
+      'exclude' => ['pxelinux.cfg','menu.c32','pxelinux.0']
     })
   end
 
@@ -79,5 +79,17 @@ describe 'tftpboot' do
     })
   end
 
+  it do
+    should contain_package('syslinux-tftpboot')
+  end
 
+  it do
+    should contain_file('/tftpboot/linux-install/pxelinux.0').with_source('file:///var/lib/tftpboot/pxelinux.0')
+    should contain_file('/tftpboot/linux-install/pxelinux.0').that_requires('Package[syslinux-tftpboot]')
+  end
+
+  it do
+    should contain_file('/tftpboot/linux-install/menu.c32').with_source('file:///var/lib/tftpboot/menu.c32')
+    should contain_file('/tftpboot/linux-install/menu.c32').that_requires('Package[syslinux-tftpboot]')
+  end
 end


### PR DESCRIPTION
This update modifies the tftpboot setup to pull as much as possible from
the native system itself.

Actual boot media will still need to be placed into rsync.

SIMP-305 #comment Update to use native pkgs
SIMP-307 #close