### PR TITLE
(SIMP-604) Migrate to simplib and simpcat

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,10 +1,11 @@
 ---
 fixtures:
   repositories:
-    common  : "git://github.com/simp/pupmod-simp-common"
-    iptables: "git://github.com/simp/pupmod-simp-iptables"
-    rsync   : "git://github.com/simp/pupmod-simp-rsync"
-    stdlib  : "git://github.com/simp/puppetlabs-stdlib"
-    xinetd  : "git://github.com/simp/pupmod-simp-xinetd"
+    common:    'git://github.com/simp/pupmod-simp-common'
+    simplib:   'git://github.com/simp/pupmod-simp-simplib'
+    iptables:  'git://github.com/simp/pupmod-simp-iptables'
+    rsync:     'git://github.com/simp/pupmod-simp-rsync'
+    stdlib:    'git://github.com/simp/puppetlabs-stdlib'
+    xinetd:    'git://github.com/simp/pupmod-simp-xinetd'
   symlinks:
     tftpboot: "#{source_dir}"

--- a/build/pupmod-tftpboot.spec
+++ b/build/pupmod-tftpboot.spec
@@ -1,7 +1,7 @@
 Summary: TFTPBoot Puppet Module
 Name: pupmod-tftpboot
 Version: 4.1.0
-Release: 7
+Release: 8
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -58,6 +58,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Mon Nov 09 2015 Chris Tessmer <chris.tessmer@onypoint.com> - 4.1.0-8
+- migration to simplib and simpcat (lib/ only)
+
 * Mon Jul 27 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-7
 - Updated to use the system-provided files where possible.
 


### PR DESCRIPTION
Before this commit, common SIMP-related custom functions were been kept
in either `simp-common` or `simp-functions`, and the `concat` function
was provided by the `simp-concat` module.  These functions are now
provides by the `simp-simplib` and `simp-simpcat` modules, respectively.

This update replaces all requirements in the RPM spec file,
metadata.json, or .fixtures.yml to reflect the migration to the new
modules.

SIMP-601 #comment Migrated `pupmod-simp-tftpboot`.
SIMP-604 #comment Updated `pupmod-simp-tftpboot`.