### PR TITLE
(SIMP-667) Normalize common module assets

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,11 +1,11 @@
 ---
 fixtures:
   repositories:
-    common:    'git://github.com/simp/pupmod-simp-common'
-    simplib:   'git://github.com/simp/pupmod-simp-simplib'
-    iptables:  'git://github.com/simp/pupmod-simp-iptables'
-    rsync:     'git://github.com/simp/pupmod-simp-rsync'
-    stdlib:    'git://github.com/simp/puppetlabs-stdlib'
-    xinetd:    'git://github.com/simp/pupmod-simp-xinetd'
+    compliance:  'https://github.com/trevor-vaughan/pupmod-compliance'
+    simplib:     'https://github.com/simp/pupmod-simp-simplib.git'
+    iptables:    'https://github.com/simp/pupmod-simp-iptables.git'
+    rsync:       'https://github.com/simp/pupmod-simp-rsync.git'
+    stdlib:      'https://github.com/simp/puppetlabs-stdlib.git'
+    xinetd:      'https://github.com/simp/pupmod-simp-xinetd.git'
   symlinks:
     tftpboot: "#{source_dir}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+.*.sw?
+.yardoc
+dist
+/pkg
+/spec/fixtures
+!/spec/hieradata/default.yaml
+!/spec/fixtures/site.pp
+/.rspec_system
+/.vagrant
+/.bundle
+/Gemfile.lock
+/vendor
+/junit
+/log

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,0 +1,4 @@
+--log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
+--relative
+--no-class_inherits_from_params_class-check
+--no-80chars-check

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--fail-fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,90 @@
 ---
 language: ruby
+sudo: false
 cache: bundler
-rvm:
-    - 1.8.7
-    - 1.9.3
-    - 2.0.0
-    - 2.2.1
-install: bundle install
+before_script:
+  - bundle
+bundler_args: --without development system_tests
+before_install: rm Gemfile.lock || true
 script:
-    - 'bundle exec rake validate'
-    - 'bundle exec rake lint'
-    - 'bundle exec rake spec'
+  - bundle exec rake test
+notifications:
+  email: false
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.2.1
+env:
+  global:
+    - STRICT_VARIABLES=yes
+    - TRUSTED_NODE_DATA=yes
+  matrix:
+  # NOTE: `:environmentpath` was not supported before Puppet 3.5
+    - PUPPET_VERSION="~> 3.5.0"
+    - PUPPET_VERSION="~> 3.6.0"
+    - PUPPET_VERSION="~> 3.7.0"
+    - PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 3.8.0"
+    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 4.0.0"
+    - PUPPET_VERSION="~> 4.1.0"
+    - PUPPET_VERSION="~> 4.2.0"
 matrix:
-    allow_failures:
-        - rvm: 1.8.7
-        - rvm: 2.2.1
+  fast_finish: true
+  allow_failures:
+    - rvm: 1.8.7
+    - rvm: 2.1.0
+    - rvm: 2.2.1
+    - env: PUPPET_VERSION="~> 3.5.0"
+    - env: PUPPET_VERSION="~> 3.6.0"
+    - env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.0.0"
+    - env: PUPPET_VERSION="~> 4.1.0"
+    - env: PUPPET_VERSION="~> 4.2.0"
+
+  exclude:
+  # Ruby 1.8.7
+  # - Ruby 1.8.7 & Puppet 4.X is impossibru
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.0.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.1.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.2.0"
+
+  # - simp-rake-helpers deps currently break between 1.8.7 and 3.X
+  # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
+  # - For Ruby 1.8.7, testing earliest and latest 3.X is sufficient.
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+
+  # Ruby 2.1.0
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.7.0"
+
+  # Ruby 2.2.1
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,92 @@
+This module has grown over time based on a range of contributions from
+people using it. If you follow these contributing guidelines your patch
+will likely make it into a release a little quicker.
+
+
 ## Contributing
 
-Please refer to the main [SIMP Project Contributing Guide](https://github.com/NationalSecurityAgency/SIMP/blob/master/CONTRIBUTING.md)
-for details on contributing to this project.
+1. Fork the repo.
+
+2. Run the tests. We only take pull requests with passing tests, and
+   it's great to know that you have a clean slate.
+
+3. Add a test for your change. Only refactoring and documentation
+   changes require no new tests. If you are adding functionality
+   or fixing a bug, please add a test.
+
+4. Make the test pass.
+
+5. Push to your fork and submit a pull request.
+
+
+## Dependencies
+
+The testing and development tools have a bunch of dependencies,
+all managed by [Bundler](http://bundler.io/) according to the
+[Puppet support matrix](http://docs.puppetlabs.com/guides/platforms.html#ruby-versions).
+
+By default the tests use a baseline version of Puppet.
+
+If you have Ruby 2.x or want a specific version of Puppet,
+you must set an environment variable such as:
+
+    export PUPPET_VERSION="~> 3.2.0"
+
+Install the dependencies like so...
+
+    bundle install
+
+## Syntax and style
+
+The test suite will run [Puppet Lint](http://puppet-lint.com/) and
+[Puppet Syntax](https://github.com/gds-operations/puppet-syntax) to
+check various syntax and style things. You can run these locally with:
+
+    bundle exec rake lint
+    bundle exec rake syntax
+
+## Running the unit tests
+
+The unit test suite covers most of the code, as mentioned above please
+add tests if you're adding new functionality. If you've not used
+[rspec-puppet](http://rspec-puppet.com/) before then feel free to ask
+about how best to test your new feature. Running the test suite is done
+with:
+
+    bundle exec rake spec
+
+Note also you can run the syntax, style and unit tests in one go with:
+
+    bundle exec rake test
+
+### Automatically run the tests
+
+During development of your puppet module you might want to run your unit
+tests a couple of times. You can use the following command to automate
+running the unit tests on every change made in the manifests folder.
+
+    bundle exec guard
+
+## Integration tests
+
+The unit tests just check the code runs, not that it does exactly what
+we want on a real machine. For that we're using
+[Beaker](https://github.com/puppetlabs/beaker).
+
+Beaker fires up a new virtual machine (using Vagrant) and runs a series of
+simple tests against it after applying the module. You can run our
+Beaker tests with:
+
+    bundle exec rake acceptance
+
+This will use the host described in `spec/acceptance/nodeset/default.yml`
+by default. To run against another host, set the `BEAKER_set` environment
+variable to the name of a host described by a `.yml` file in the
+`nodeset` directory. For example, to run against CentOS 6.4:
+
+    BEAKER_set=centos-64-x64 bundle exec rake acceptance
+
+If you don't want to have to recreate the virtual machine every time you
+can use `BEAKER_destroy=no` and `BEAKER_provision=no`. On the first run you will
+at least need `BEAKER_provision` set to yes (the default). The Vagrantfile
+for the created virtual machines will be in `.vagrant/beaker_vagrant_files`.

--- a/Gemfile
+++ b/Gemfile
@@ -2,22 +2,51 @@
 #
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
-puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['~>3']
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~>3'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
 
+group :test do
+  gem "rake"
+  gem 'puppet', puppetversion
+  gem "rspec", '< 3.2.0'
+  gem "rspec-puppet"
+  gem "puppetlabs_spec_helper"
+  gem "metadata-json-lint"
+  gem "simp-rspec-puppet-facts"
 
-gem 'puppet', puppetversion
-gem 'puppet-lint'
-gem 'puppetlabs_spec_helper'
-gem 'puppet_module_spec_helper'
-gem 'simp-rake-helpers'
+  # dependency hacks:
+  gem "fog-google", '~> 0.0.9' # 0.1 dropped support for ruby 1.9
 
-group :debug do
-    gem 'pry'
-    gem 'pry-doc'
-    gem 'rspec'
-    gem 'mocha'
-    gem 'metadata-json-lint'
+  # simp-rake-helpers does not suport puppet 2.7.X
+  if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
+      # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
+      # TODO: fix upstream deps (parallel in simp-rake-helpers)
+      RUBY_VERSION.sub(/\.\d+$/,'') != '1.8'
+    gem 'simp-rake-helpers'
+  end
+end
+
+group :development do
+  gem "travis"
+  gem "travis-lint"
+  gem "vagrant-wrapper"
+  gem "puppet-blacksmith"
+  gem "guard-rake"
+  gem 'pry'
+  gem 'pry-doc'
+end
+
+group :system_tests do
+  gem 'beaker'
+  gem 'beaker-rspec'
+
+  # 1.0.5 introduces FIPS-first acc tests
+  gem 'simp-beaker-helpers', '>= 1.0.5'
+
+  # dependency hacks:
+  # NOTE: Workaround because net-ssh 2.10 is busting beaker
+  # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
+  gem 'net-ssh', '~> 2.9.0'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,28 +1,68 @@
-#!/usr/bin/rake -T
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet/version'
+require 'puppet/vendor/semantic/lib/semantic' unless Puppet.version.to_f < 3.6
+require 'puppet-syntax/tasks/puppet-syntax'
+require 'puppet-lint/tasks/puppet-lint'
 
-# For playing nice with mock
-File.umask(027)
+# These gems aren't always present, for instance
+# on Travis with --without development
+begin
+  require 'puppet_blacksmith/rake_tasks'
+rescue LoadError
+end
 
-require 'simp/rake/pkg'
+
+# Lint & Syntax exclusions
+exclude_paths = [
+  "bundle/**/*",
+  "pkg/**/*",
+  "dist/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+]
+PuppetSyntax.exclude_paths = exclude_paths
+
+# See: https://github.com/rodjek/puppet-lint/pull/397
+Rake::Task[:lint].clear
+PuppetLint.configuration.ignore_paths = exclude_paths
+PuppetLint::RakeTask.new :lint do |config|
+  config.ignore_paths = PuppetLint.configuration.ignore_paths
+end
 
 begin
-  require 'puppetlabs_spec_helper/rake_tasks'
+  require 'simp/rake/pkg'
+  Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
+    t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+  end
 rescue LoadError
-  puts "== WARNING: Gem puppetlabs_spec_helper not found, spec tests cannot be run! =="
+  puts "== WARNING: Gem simp-rake-helpers not found, pkg: tasks cannot be run! =="
 end
 
-# Lint Material
 begin
-  require 'puppet-lint/tasks/puppet-lint'
-
-  PuppetLint.configuration.send("disable_80chars")
-  PuppetLint.configuration.send("disable_variables_not_enclosed")
-  PuppetLint.configuration.send("disable_class_parameter_defaults")
-  PuppetLint.configuration.send("disable_selector_inside_resource")
+  require 'simp/rake/beaker'
+  Simp::Rake::Beaker.new( File.dirname( __FILE__ ) )
 rescue LoadError
-  puts "== WARNING: Gem puppet-lint not found, lint tests cannot be run! =="
+  # Ignoring this for now since all of these are currently convenience methods.
 end
 
-Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
-  t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+desc "Run acceptance tests"
+RSpec::Core::RakeTask.new(:acceptance) do |t|
+  t.pattern = 'spec/acceptance'
 end
+
+desc "Populate CONTRIBUTORS file"
+task :contributors do
+  system("git log --format='%aN' | sort -u > CONTRIBUTORS")
+end
+
+task :metadata do
+  sh "metadata-json-lint metadata.json"
+end
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :syntax,
+  :lint,
+  :spec,
+  :metadata,
+]

--- a/build/pupmod-tftpboot.spec
+++ b/build/pupmod-tftpboot.spec
@@ -1,7 +1,7 @@
 Summary: TFTPBoot Puppet Module
 Name: pupmod-tftpboot
 Version: 4.1.0
-Release: 8
+Release: 9
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -58,6 +58,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Wed Mar 02 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.1.0-9
+- Minor linting fixes
+
 * Mon Nov 09 2015 Chris Tessmer <chris.tessmer@onypoint.com> - 4.1.0-8
 - migration to simplib and simpcat (lib/ only)
 

--- a/manifests/assign_host.pp
+++ b/manifests/assign_host.pp
@@ -27,14 +27,18 @@ define tftpboot::assign_host (
   $model,
   $ensure = 'present'
 ) {
+  validate_string($model)
+  validate_re($ensure,'^(absent|present)$')
+
   $upname = inline_template('<%= @name.upcase %>')
   $downname = inline_template('<%= @name.downcase %>')
+  $_ensure = $ensure ? {
+    'present' => link,
+    default   => 'absent'
+  }
 
   file { "/tftpboot/linux-install/pxelinux.cfg/${downname}":
-    ensure => $ensure ? {
-      'present' => link,
-      default   => 'absent'
-    },
+    ensure => $_ensure,
     owner  => 'root',
     group  => 'nobody',
     mode   => '0644',
@@ -45,10 +49,7 @@ define tftpboot::assign_host (
   $l_a_downname = split($downname,' ')
   if ( $downname != 'default' ) and ( ! ( $upname in $l_a_downname ) ) {
     file { "/tftpboot/linux-install/pxelinux.cfg/${upname}":
-      ensure => $ensure ? {
-        'present' => link,
-        default   => 'absent'
-      },
+      ensure => $_ensure,
       owner  => 'root',
       group  => 'nobody',
       mode   => '0644',
@@ -56,7 +57,4 @@ define tftpboot::assign_host (
       force  => true
     }
   }
-
-  validate_string($model)
-  validate_re($ensure,'^(absent|present)$')
 }

--- a/manifests/generic_model.pp
+++ b/manifests/generic_model.pp
@@ -22,6 +22,9 @@ define tftpboot::generic_model (
   $content,
   $ensure = 'present'
 ) {
+    validate_string($content)
+    validate_re($ensure, '^(absent|present)$')
+
     file { "/tftpboot/pxe-linux/templates/${name}":
         ensure  => $ensure,
         owner   => 'root',
@@ -29,7 +32,4 @@ define tftpboot::generic_model (
         mode    => '0640',
         content => $content
     }
-
-    validate_string($content)
-    validate_re($ensure, '^(absent|present)$')
 }

--- a/manifests/linux_model.pp
+++ b/manifests/linux_model.pp
@@ -40,6 +40,13 @@ define tftpboot::linux_model (
   $ensure = 'present',
   $fips = hiera('use_fips', false)
 ){
+  validate_string($kernel)
+  validate_string($initrd)
+  validate_string($ks)
+  if $extra != 'nil' { validate_string($extra) }
+  validate_re($ensure, '^(absent|present)$')
+  validate_bool($fips)
+
   file { "/tftpboot/linux-install/pxelinux.cfg/templates/${name}":
     ensure  => $ensure,
     owner   => 'root',
@@ -47,11 +54,4 @@ define tftpboot::linux_model (
     content => template('tftpboot/entry.erb'),
     mode    => '0644'
   }
-
-  validate_string($kernel)
-  validate_string($initrd)
-  validate_string($ks)
-  if $extra != 'nil' { validate_string($extra) }
-  validate_re($ensure, '^(absent|present)$')
-  validate_bool($fips)
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,41 @@
+{
+  "name":    "pupmod-simp-tftpboot",
+  "version": "4.1.0",
+  "author":  "simp",
+  "summary": "A Puppet module to automate configuration of tftpboot",
+  "license": "Apache-2.0",
+  "source":  "https://github.com/simp/pupmod-simp-tftpboot",
+  "project_page": "https://github.com/simp/pupmod-simp-tftpboot",
+  "issues_url":   "https://simp-project.atlassian.net",
+  "tags": [ "simp", "tftpboot" ],
+  "dependencies": [
+    {
+      "name": "puppetlabs-stdlib",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-xinetd",
+      "version_requirement": ">= 2.0.0"
+    },
+    {
+      "name": "simp-rsync",
+      "version_requirement": ">= 2.0.0"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ]
+}

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 describe 'tftpboot' do
 
-  it { should create_class('tftpboot') }
+  it { is_expected.to create_class('tftpboot') }
 
   it do
-    should contain_file('/tftpboot').with({
+    is_expected.to contain_file('/tftpboot').with({
       'ensure' => 'directory',
       'owner' => 'root',
       'group' => 'nobody',
@@ -15,7 +15,7 @@ describe 'tftpboot' do
   end
 
   it do
-    should contain_file('/tftpboot/linux-install').with({
+    is_expected.to contain_file('/tftpboot/linux-install').with({
       'ensure' => 'directory',
       'owner' => 'root',
       'group' => 'nobody',
@@ -24,7 +24,7 @@ describe 'tftpboot' do
   end
 
   it do
-    should contain_file('/tftpboot/linux-install/pxelinux.cfg').with({
+    is_expected.to contain_file('/tftpboot/linux-install/pxelinux.cfg').with({
       'ensure' => 'directory',
       'owner' => 'root',
       'group' => 'nobody',
@@ -37,7 +37,7 @@ describe 'tftpboot' do
   end
 
   it do
-    should contain_file('/tftpboot/linux-install/pxelinux.cfg/templates').with({
+    is_expected.to contain_file('/tftpboot/linux-install/pxelinux.cfg/templates').with({
       'ensure' => 'directory',
       'owner' => 'root',
       'group' => 'nobody',
@@ -47,10 +47,10 @@ describe 'tftpboot' do
     })
   end
 
-  it { should contain_package('tftp-server') }
+  it { is_expected.to contain_package('tftp-server') }
 
   it do
-    should contain_rsync('tftpboot').with({
+    is_expected.to contain_rsync('tftpboot').with({
       'user' => 'tftpboot_rsync',
       'password' => /^.+$/,
       'source' => 'tftpboot/*',
@@ -62,7 +62,7 @@ describe 'tftpboot' do
   end
 
   it do
-    should contain_xinetd__service('tftp').with({
+    is_expected.to contain_xinetd__service('tftp').with({
       'x_type' => 'unlisted',
       'socket_type' => 'dgram',
       'protocol' => 'udp',
@@ -80,16 +80,16 @@ describe 'tftpboot' do
   end
 
   it do
-    should contain_package('syslinux-tftpboot')
+    is_expected.to contain_package('syslinux-tftpboot')
   end
 
   it do
-    should contain_file('/tftpboot/linux-install/pxelinux.0').with_source('file:///var/lib/tftpboot/pxelinux.0')
-    should contain_file('/tftpboot/linux-install/pxelinux.0').that_requires('Package[syslinux-tftpboot]')
+    is_expected.to contain_file('/tftpboot/linux-install/pxelinux.0').with_source('file:///var/lib/tftpboot/pxelinux.0')
+    is_expected.to contain_file('/tftpboot/linux-install/pxelinux.0').that_requires('Package[syslinux-tftpboot]')
   end
 
   it do
-    should contain_file('/tftpboot/linux-install/menu.c32').with_source('file:///var/lib/tftpboot/menu.c32')
-    should contain_file('/tftpboot/linux-install/menu.c32').that_requires('Package[syslinux-tftpboot]')
+    is_expected.to contain_file('/tftpboot/linux-install/menu.c32').with_source('file:///var/lib/tftpboot/menu.c32')
+    is_expected.to contain_file('/tftpboot/linux-install/menu.c32').that_requires('Package[syslinux-tftpboot]')
   end
 end

--- a/spec/defines/assign_host_spec.rb
+++ b/spec/defines/assign_host_spec.rb
@@ -7,7 +7,7 @@ describe 'tftpboot::assign_host' do
   let(:params) { {:model => 'rhel-6-x86_64-base'} }
 
   it do
-    should contain_file('/tftpboot/linux-install/pxelinux.cfg/default').with({
+    is_expected.to contain_file('/tftpboot/linux-install/pxelinux.cfg/default').with({
       'ensure' => 'link',
       'target' => 'templates/rhel-6-x86_64-base',
       'force'  => true
@@ -19,14 +19,14 @@ describe 'tftpboot::assign_host' do
     let(:params) { {:model => '64_bit_rhel6'} }
 
     it do
-      should contain_file('/tftpboot/linux-install/pxelinux.cfg/de-ad-be-ef-00-01').with({
+      is_expected.to contain_file('/tftpboot/linux-install/pxelinux.cfg/de-ad-be-ef-00-01').with({
         'ensure' => 'link',
         'target' => 'templates/64_bit_rhel6',
         'force' => true
       })
     end
     it do
-      should contain_file('/tftpboot/linux-install/pxelinux.cfg/DE-AD-BE-EF-00-01').with({
+      is_expected.to contain_file('/tftpboot/linux-install/pxelinux.cfg/DE-AD-BE-EF-00-01').with({
         'ensure' => 'link',
         'target' => 'templates/64_bit_rhel6',
         'force' => true

--- a/spec/defines/generic_model_spec.rb
+++ b/spec/defines/generic_model_spec.rb
@@ -7,7 +7,7 @@ describe 'tftpboot::generic_model' do
   let(:params) { {:content => 'foobarbaz'} }
 
   it do
-    should contain_file('/tftpboot/pxe-linux/templates/rhel_model').with({
+    is_expected.to contain_file('/tftpboot/pxe-linux/templates/rhel_model').with({
       'ensure' => 'present',
       'owner'  => 'root',
       'group'  => 'nobody',

--- a/spec/defines/linux_model_spec.rb
+++ b/spec/defines/linux_model_spec.rb
@@ -8,7 +8,7 @@ describe 'tftpboot::linux_model' do
                   :ks => 'http://localhost/ks/pupclient_x86_64.cfg'} }
 
   it do
-    should contain_file("/tftpboot/linux-install/pxelinux.cfg/templates/rhel_model").with({
+    is_expected.to contain_file("/tftpboot/linux-install/pxelinux.cfg/templates/rhel_model").with({
       'ensure' => 'present',
       'owner' => 'root',
       'group' => 'nobody',


### PR DESCRIPTION
This commit synchronizes all common static module assets with current SIMP
module standards.

Also:
- updated rspec tests to the new `expect` syntax
- fixed linting errors
- moved validations to the tops of classes
- bumped RPM to 4.1.0-9
- created .puppet-lint.rc, .gitignore, .rspec

SIMP-667 #comment updated `pupmod-simp-tftpboot`
SIMP-761 #close #comment normalized common module assets