### PR TITLE
(SIMP-1064) Optionally enable FIPS.

### DIFF
--- a/build/pupmod-tftpboot.spec
+++ b/build/pupmod-tftpboot.spec
@@ -1,7 +1,7 @@
 Summary: TFTPBoot Puppet Module
 Name: pupmod-tftpboot
-Version: 4.1.0
-Release: 9
+Version: 4.1.1
+Release: 0
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -58,6 +58,10 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Wed May 11 2016 Nick Markowski <nmarkowski@keywcorp.com> - 4.1.1-0
+- Inclusion of FIPS in the initrd kickstart option list is now optional.
+  By default, we no longer set fips=1 in initrd.
+
 * Wed Mar 02 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.1.0-9
 - Minor linting fixes
 

--- a/manifests/linux_model.pp
+++ b/manifests/linux_model.pp
@@ -24,8 +24,14 @@
 #   Can be set to 'absent' or 'present'.
 #   Defaults to present.
 #
+# [*set_fips_initrd*]
+#   Boolean.  If true, enables [*fips*] logic in the initrd configuration, otherwise
+#   fips is omitted.  WARNING: setting this to true while using the stock EL7
+#   initrd image will cause kickstart to fail if SSL is utilized (https by default).
+#   Defaults to false.
+#
 # [*fips*]
-#   Boolean.  If true, enables FIPS in the grub configuration.
+#   Boolean.  If true, enables FIPS in the grub and initrd configuration.
 #   Defaults to false.
 #
 # == Authors
@@ -38,7 +44,8 @@ define tftpboot::linux_model (
   $ks,
   $extra = 'nil',
   $ensure = 'present',
-  $fips = hiera('use_fips', false)
+  $set_fips_initrd = false,
+  $fips = hiera('use_fips', false),
 ){
   validate_string($kernel)
   validate_string($initrd)
@@ -46,6 +53,7 @@ define tftpboot::linux_model (
   if $extra != 'nil' { validate_string($extra) }
   validate_re($ensure, '^(absent|present)$')
   validate_bool($fips)
+  validate_bool($set_fips_initrd)
 
   file { "/tftpboot/linux-install/pxelinux.cfg/templates/${name}":
     ensure  => $ensure,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "pupmod-simp-tftpboot",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "author":  "simp",
   "summary": "A Puppet module to automate configuration of tftpboot",
   "license": "Apache-2.0",

--- a/templates/entry.erb
+++ b/templates/entry.erb
@@ -3,4 +3,4 @@
 default 0
 label 0
         kernel <%= @kernel %>
-        append initrd=<%= @initrd %> ks=<%= @ks %> fips=<%= l_fips %> <% if !@extra.eql?("nil") then %><%= @extra %><% end %>
+        append initrd=<%= @initrd %> ks=<%= @ks %> <% if @set_fips_initrd then %> fips=<%= l_fips %><% end %> <% if !@extra.eql?("nil") then %><%= @extra %><% end %>


### PR DESCRIPTION
- Inclusion of FIPS in the initrd kickstart option list is now optional.
- By default, we no longer set fips=1 in initrd. This stems from a bug
  in el7.

SIMP-1064 #comment tftpboot FIPS optional