### PR TITLE
(SIMP-6114) Use namespaced simplib::nets2ddq

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Mar 19 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.2.2-0
+- Use simplib::nets2ddq in lieu of deprecated Puppet 3 nets2ddq
+
 * Thu Mar 07 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.2.1-0
 - Update the upper bound of stdlib to < 6.0.0
 - Update a URL in the README.md

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,7 +81,7 @@ class tftpboot (
     per_source     => 11,
     cps            => [100,2],
     flags          => ['IPv4'],
-    trusted_nets   => nets2ddq($trusted_nets),
+    trusted_nets   => simplib::nets2ddq($trusted_nets),
     log_on_success => ['HOST', 'PID', 'DURATION'],
     require        => [ Package['tftp-server'], File[$tftpboot_root_dir] ]
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-tftpboot",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "author": "SIMP Team",
   "summary": "A Puppet module to automate configuration of tftpboot",
   "license": "Apache-2.0",
@@ -26,7 +26,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
+      "version_requirement": ">= 3.8.0 < 4.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Use simplib::nets2ddq in lieu of deprecated Puppet 3 nets2ddq

SIMP-6114 #comment pupmod-simp-tftpboot