### PR TITLE
(SIMP-8459) Preserve ownership of rsync'd files

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Thu Oct 22 2020 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.3.1-0
+- (Re-)preserve rsync'd files' ownership, permissions, and SELinux contexts
+
 * Tue Dec 03 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.3.0-0
 - Update README.md
 - Add REFERENCE.md

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -37,18 +37,13 @@ class tftpboot::config {
     include 'rsync'
 
     rsync { 'tftpboot':
-      user            => "tftpboot_rsync_${::environment}_${_downcase_osname}",
-      password        => simplib::passgen("tftpboot_rsync_${::environment}_${_downcase_osname}"),
-      source          => $tftpboot::rsync_source,
-      target          => $tftpboot::tftpboot_root_dir,
-      server          => $tftpboot::rsync_server,
-      timeout         => $tftpboot::rsync_timeout,
-      exclude         => $_rsync_exclude,
-      preserve_owner  => false,
-      preserve_group  => false,
-      preserve_perms  => false,
-      preserve_acl    => false,
-      preserve_xattrs => false,
+      user     => "tftpboot_rsync_${::environment}_${_downcase_osname}",
+      password => simplib::passgen("tftpboot_rsync_${::environment}_${_downcase_osname}"),
+      source   => $tftpboot::rsync_source,
+      target   => $tftpboot::tftpboot_root_dir,
+      server   => $tftpboot::rsync_server,
+      timeout  => $tftpboot::rsync_timeout,
+      exclude  => $_rsync_exclude,
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-tftpboot",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "author": "SIMP Team",
   "summary": "A Puppet module to automate configuration of tftpboot",
   "license": "Apache-2.0",


### PR DESCRIPTION
This patch addresses a recently-introduced bug that suppressed all
ownership, permissions, and SELinux contexts from rsync'd tftpboot image
files.  This resulted in tftpboot template files with default
(locked-down and root-only) permissions, which ths tftpboot service
(group `nobody`) was unable to access.

This patch reverts to the original rsync behavior, which is intended to
preserve file permissons, ownership, and SELinux contexts through to the
destination.

[SIMP-8459] #close

[SIMP-8459]: https://simp-project.atlassian.net/browse/SIMP-8459