### PR TITLE
Remove unmaintained Compliance Engine data

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,6 +6,5 @@ fixtures:
     selinux_core: https://github.com/simp/pupmod-puppetlabs-selinux_core.git
     simplib: https://github.com/simp/pupmod-simp-simplib.git
     stdlib: https://github.com/simp/puppetlabs-stdlib.git
-    compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup.git
   symlinks:
     tftpboot: "#{source_dir}"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,10 +28,6 @@ default_hiera_config = <<~HIERA_CONFIG
   ---
   version: 5
   hierarchy:
-    - name: SIMP Compliance Engine
-      lookup_key: compliance_markup::enforcement
-      options:
-        enabled_sce_versions: [2]
     - name: Custom Test Hiera
       path: "%{custom_hiera}.yaml"
     - name: "%{module_name}"


### PR DESCRIPTION
This module never contained `SIMP/compliance_profiles` data, but still carried the `compliance_markup` fixture and the SIMP Compliance Engine Hiera hierarchy entry from when it was wired up for compliance testing.